### PR TITLE
Add C# Namespace setting; Fix uint overflow at max bit size

### DIFF
--- a/addons/layerNames/layerNames_plugin.gd
+++ b/addons/layerNames/layerNames_plugin.gd
@@ -145,10 +145,12 @@ func _create_enum_string(language: OutputLanguage, layer_type: String, max_layer
 	var enum_indent := "\t\t" if language == OutputLanguage.CSharp else ""
 	var entry_indent := "\t\t\t" if language == OutputLanguage.CSharp else "\t"
 	var public_keyword := "public " if language == OutputLanguage.CSharp else ""
+	var base_class := " : uint" if language == OutputLanguage.CSharp else ""
 	
 	var enum_parts := PackedStringArray()
 	enum_parts.append("%s%senum " % [enum_indent, public_keyword])
 	enum_parts.append(enum_name)
+	enum_parts.append(base_class)
 	enum_parts.append(" {\n")
 	enum_parts.append("%sNONE_NUM = 0,\n" % entry_indent)
 	enum_parts.append("%sNONE_BIT = 0,\n" % entry_indent)
@@ -182,9 +184,8 @@ func _generate_enum_entry(language: OutputLanguage, layer_number: int, layer_nam
 	
 	var entry_indent := "\t\t\t" if language == OutputLanguage.CSharp else "\t"
 	var bit_value := 1 << (layer_number - BIT_SHIFT_OFFSET)
-	
-	if (layer_number == 32):
-		bit_value = bit_value - 1;
+	#if (layer_number == 32):
+		#bit_value = bit_value - 1;
 	
 	var entry_parts := PackedStringArray()
 	entry_parts.append("%s%s_NUM = %s,\n" % [entry_indent, key, layer_number])

--- a/addons/layerNames/layerNames_plugin.gd
+++ b/addons/layerNames/layerNames_plugin.gd
@@ -184,8 +184,6 @@ func _generate_enum_entry(language: OutputLanguage, layer_number: int, layer_nam
 	
 	var entry_indent := "\t\t\t" if language == OutputLanguage.CSharp else "\t"
 	var bit_value := 1 << (layer_number - BIT_SHIFT_OFFSET)
-	#if (layer_number == 32):
-		#bit_value = bit_value - 1;
 	
 	var entry_parts := PackedStringArray()
 	entry_parts.append("%s%s_NUM = %s,\n" % [entry_indent, key, layer_number])


### PR DESCRIPTION
### FEATURE: 
My own use-case for the plugin had me wanting to set my own custom namespace for the generated C# file. I figured this may be desired by other developers too, so I made it a project setting with a default value of "Godot".
<img width="762" height="152" alt="image" src="https://github.com/user-attachments/assets/134891ad-0cac-415f-8d84-5f92919d15d7" />
(I changed the value to "MyProject" just to illustrate an example.)

### BUG-FIX: 
Out of the box, the generated C# file threw errors with the maximum bit sizes:

LAYER_32_BIT = 2147483648,
> Cannot convert source type '`uint`' to target type '`int`'.
<img width="502" height="55" alt="image" src="https://github.com/user-attachments/assets/5890e77b-8b86-441c-99c2-351f41752af3" />


My "fix":
```gdscript
	if (layer_number == 32):
		bit_value = bit_value - 1;
```

It's a bit of a hacky bandaid, as I don't know if this will behave properly, but it will at least compile correctly once it generates. I don't personally use bit values, though, so I'm not sure about the behavior.