### PR TITLE
Stop making project changes on startup or shutdown, Sanitize projectsettings management

### DIFF
--- a/addons/layerNames/layerNames_plugin.gd
+++ b/addons/layerNames/layerNames_plugin.gd
@@ -50,33 +50,39 @@ func _enter_tree() -> void:
 
 func _disable_plugin() -> void:
 	ProjectSettings.settings_changed.disconnect(_update_layer_names)
+	_remove_project_settings()
 	remove_autoload_singleton(SINGLETON_NAME)
 	layer_settings_cache.clear()
 
 func _register_project_settings() -> void:
 	if not ProjectSettings.has_setting(OUTPUT_SETTING_KEY):
 		ProjectSettings.set_setting(OUTPUT_SETTING_KEY, OutputLanguage.GDScript)
-		ProjectSettings.add_property_info({
-			"name": OUTPUT_SETTING_KEY,
-			"type": TYPE_INT,
-			"hint": PROPERTY_HINT_ENUM,
-			"hint_string": "GDScript,C#,Both",
-			"default": OutputLanguage.GDScript
-		})
-		ProjectSettings.save()
-		
+	ProjectSettings.add_property_info({
+		"name": OUTPUT_SETTING_KEY,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": "GDScript,C#,Both",
+		"default": OutputLanguage.GDScript
+	})
 	ProjectSettings.set_initial_value(OUTPUT_SETTING_KEY, OutputLanguage.GDScript)
 		
 	if not ProjectSettings.has_setting(NAMESPACE_SETTING_KEY):
 		ProjectSettings.set_setting(NAMESPACE_SETTING_KEY, CSHARP_NAMESPACE_DEFAULT)
-		ProjectSettings.add_property_info({
-			"name": NAMESPACE_SETTING_KEY,
-			"type": TYPE_STRING,
-			"default": CSHARP_NAMESPACE_DEFAULT
-		})
-		ProjectSettings.save()
-
+	ProjectSettings.add_property_info({
+		"name": NAMESPACE_SETTING_KEY,
+		"type": TYPE_STRING,
+		"default": CSHARP_NAMESPACE_DEFAULT
+	})
 	ProjectSettings.set_initial_value(NAMESPACE_SETTING_KEY, CSHARP_NAMESPACE_DEFAULT)
+	
+	ProjectSettings.save()
+
+func _remove_project_settings() -> void:
+	ProjectSettings.clear(OUTPUT_SETTING_KEY)
+	
+	ProjectSettings.clear(NAMESPACE_SETTING_KEY)
+	
+	ProjectSettings.save()
 
 func _update_layer_names() -> void:
 	wait_tickets += 1
@@ -238,5 +244,8 @@ func _sanitise(input: String) -> String:
 	return output if output.is_valid_identifier() else ""
 
 func _add_or_update_singleton(name:String, path:String) -> void:
-	if not ProjectSettings.has_setting("autoload/" + name) or ProjectSettings.get_setting("autoload/" + name) !=  "*" + ResourceUID.path_to_uid(path):
+	if not ProjectSettings.has_setting("autoload/" + name):
 		add_autoload_singleton(name, path)
+	if ProjectSettings.get_setting("autoload/" + name) !=  "*" + path:
+		ProjectSettings.set_setting("autoload/" + name, "*" + path) # force path
+		ProjectSettings.save()

--- a/addons/layerNames/layerNames_plugin.gd
+++ b/addons/layerNames/layerNames_plugin.gd
@@ -48,7 +48,7 @@ func _enter_tree() -> void:
 	
 	_update_layer_names()
 
-func _exit_tree() -> void:
+func _disable_plugin() -> void:
 	ProjectSettings.settings_changed.disconnect(_update_layer_names)
 	remove_autoload_singleton(SINGLETON_NAME)
 	layer_settings_cache.clear()
@@ -98,6 +98,7 @@ func _update_layer_names() -> void:
 			_generate_gdscript_file()
 
 func _write_to_file(file_path: String, content: String) -> void:
+	if FileAccess.get_file_as_string(file_path) == content: return
 	var file := FileAccess.open(file_path, FileAccess.WRITE)
 	file.store_string(content)
 	file.close()
@@ -119,7 +120,7 @@ func _generate_gdscript_file() -> void:
 
 	print("Regenerating LayerNames GDScript enums")
 	_write_to_file(OUTPUT_FILE_GDSCRIPT, current_text)
-	add_autoload_singleton(SINGLETON_NAME, OUTPUT_FILE_GDSCRIPT)
+	_add_or_update_singleton(SINGLETON_NAME, OUTPUT_FILE_GDSCRIPT)
 	previous_gdscript_hash = current_hash
 
 func _generate_csharp_file() -> void:
@@ -145,7 +146,7 @@ func _generate_csharp_file() -> void:
 
 	print("Regenerating LayerNames C# enums")
 	_write_to_file(OUTPUT_FILE_CSHARP, current_text)
-	add_autoload_singleton(SINGLETON_NAME, OUTPUT_FILE_CSHARP)
+	_add_or_update_singleton(SINGLETON_NAME, OUTPUT_FILE_CSHARP)
 	previous_csharp_hash = current_hash
 
 func _generate_singleton_boilerplate() -> String:
@@ -235,3 +236,7 @@ func _sanitise(input: String) -> String:
 	output = output.to_snake_case().to_upper()
 
 	return output if output.is_valid_identifier() else ""
+
+func _add_or_update_singleton(name:String, path:String) -> void:
+	if not ProjectSettings.has_setting("autoload/" + name) or ProjectSettings.get_setting("autoload/" + name) !=  "*" + ResourceUID.path_to_uid(path):
+		add_autoload_singleton(name, path)


### PR DESCRIPTION
The plugin currently marks the project as changed on startup and on shutdown. The little \* on the top left maybe doesn't bother some, but it bothers me as I like having full control over what changes I'm making to a project.

It also seems to save the autoload initially at path but on later boots it gets converted to uid because of godots add_autoload_singleton implementation. This adds unnecessary changes to version control after I think I'm done setting up the plugin.

Finally if a setting has been saved (nondefault) the setting hints aren't set. What this means is that once the ENUM for OUTPUT_SETTING_KEY is set once, next boot it'd appear as an INT instead of enums to pick from.

All of the above is addressed here.